### PR TITLE
Suggested Changes

### DIFF
--- a/BuildaKit/StorageManager.swift
+++ b/BuildaKit/StorageManager.swift
@@ -21,7 +21,6 @@ public class StorageManager {
     private(set) public var servers: [XcodeServerConfig] = []
     private(set) public var projects: [Project] {
         didSet {
-            
             NSNotificationCenter.defaultCenter().postNotificationName(ProjectsDidChangeNotification, object: self)
         }
     }
@@ -145,8 +144,8 @@ public class StorageManager {
         
         self.loadProjects()
         self.loadServers()
-        self.loadSyncers()
         self.loadBuildTemplates()
+        self.loadSyncers()
     }
     
     func loadServers() {

--- a/Buildasaur.xcodeproj/project.pbxproj
+++ b/Buildasaur.xcodeproj/project.pbxproj
@@ -85,8 +85,6 @@
 		3AF090B81B1134AA0058567F /* BranchWatchingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF090B71B1134AA0058567F /* BranchWatchingViewController.swift */; };
 		3AF1B1241AAC7CA500917EF3 /* StatusSyncerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF1B1231AAC7CA500917EF3 /* StatusSyncerViewController.swift */; };
 		55A43BAC1B8CDE4300EED079 /* ProjectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A43BAB1B8CDE4300EED079 /* ProjectViewController.swift */; settings = {ASSET_TAGS = (); }; };
-		6604F68F1B8F4E4900E70BA2 /* XcodeServerSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6604F68E1B8F4E4900E70BA2 /* XcodeServerSDK.framework */; };
-		6604F6901B8F4E4900E70BA2 /* XcodeServerSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6604F68E1B8F4E4900E70BA2 /* XcodeServerSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		72C942865E06140723569CF1 /* Pods_Buildasaur.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFC5293812E0E442BE2182D0 /* Pods_Buildasaur.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		B967DFBE36176FD9B4960410 /* Pods_BuildaGitServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73C0D6A9CBF4A8155E3A7376 /* Pods_BuildaGitServer.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		EC160F5DE92FC57D64786D8F /* Pods_BuildaKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1086D69942F8B7830B5D00E1 /* Pods_BuildaKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -152,7 +150,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				6604F6901B8F4E4900E70BA2 /* XcodeServerSDK.framework in Embed Frameworks */,
 				3AAF6EFC1A3CE5BA00C657FB /* BuildaGitServer.framework in Embed Frameworks */,
 				3A81BB2C1B5A77E9004732CD /* BuildaKit.framework in Embed Frameworks */,
 			);
@@ -258,7 +255,6 @@
 		55C60ECC1B8CDD69006848B4 /* XcodeServerSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XcodeServerSDK.framework; path = Build/Products/Debug/XcodeServerSDK.framework; sourceTree = "<group>"; };
 		5A1BF45FB90783C591B4D525 /* Pods-BuildaGitServer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaGitServer.release.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaGitServer/Pods-BuildaGitServer.release.xcconfig"; sourceTree = "<group>"; };
 		60565EAEB9A1817A1DEB0FF2 /* Pods-BuildaGitServerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaGitServerTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaGitServerTests/Pods-BuildaGitServerTests.debug.xcconfig"; sourceTree = "<group>"; };
-		6604F68E1B8F4E4900E70BA2 /* XcodeServerSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = XcodeServerSDK.framework; path = "/Users/dcilia/Library/Developer/Xcode/DerivedData/Buildasaur-bedfsdjrepatehfsnnolyxngokev/Build/Products/Debug/XcodeServerSDK.framework"; sourceTree = "<absolute>"; };
 		681D44417C140BD1795F71E4 /* Pods-BuildaGitServer.testing.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BuildaGitServer.testing.xcconfig"; path = "Pods/Target Support Files/Pods-BuildaGitServer/Pods-BuildaGitServer.testing.xcconfig"; sourceTree = "<group>"; };
 		7194D95E34FC188EF9A1BAB1 /* Pods_BuildasaurTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BuildasaurTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		73C0D6A9CBF4A8155E3A7376 /* Pods_BuildaGitServer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BuildaGitServer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -286,7 +282,6 @@
 			files = (
 				3A81BB2B1B5A77E9004732CD /* BuildaKit.framework in Frameworks */,
 				3AAF6EFB1A3CE5BA00C657FB /* BuildaGitServer.framework in Frameworks */,
-				6604F68F1B8F4E4900E70BA2 /* XcodeServerSDK.framework in Frameworks */,
 				72C942865E06140723569CF1 /* Pods_Buildasaur.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -363,7 +358,6 @@
 		3A5687671A3B93BD0066DB2B = {
 			isa = PBXGroup;
 			children = (
-				6604F68E1B8F4E4900E70BA2 /* XcodeServerSDK.framework */,
 				3A5687721A3B93BD0066DB2B /* Buildasaur */,
 				3A81BB171B5A77E9004732CD /* BuildaKit */,
 				3A81BB251B5A77E9004732CD /* BuildaKitTests */,

--- a/Buildasaur/AppDelegate.swift
+++ b/Buildasaur/AppDelegate.swift
@@ -27,6 +27,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         Logging.setup(alsoIntoFile: true)
         self.menuItemManager.setupMenuBarItem()
+        
+        //starts syncing right after app gets launched - not smart in GUI mode
+        //but you can see that syncers get loaded correctly and work for multiple projects just fine already.
+        //we need the UI to be able to create a new syncer (not a new project)
+//        StorageManager.sharedInstance.startSyncers()
     }
 
     func applicationShouldHandleReopen(sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {


### PR DESCRIPTION
Hey - just wanted to show you how to test that multiple syncers already work under the hood (and also how to remove the XcodeServerSDK project changes - just run `pod install`).

The thing is - the way I designed Buildasaur is that we have something called a **Syncer** - which points to one project (which code to test) and one Xcode Server (where to test it), plus a couple of preferences (sync interval etc). You can see these in `~/Library/Application Support/Buildasaur` and in `Projects.json`, `ServerConfigs.json` and `Syncers.json`. You'll notice all of them are **arrays**, so that we can store many of them. Also, if you look into `Syncers`, you'll see that a syncer has a `project_path` (which tells it which *project* to use) and a `server_host` (to know which server to use).

So we have a bunch of servers and projects. We build syncers on top of them - those do the actual syncing and that's what we want to have multiple of. In the UI you added, it'd be great if you could change it to list multiple syncers in the main table, instead of projects (because syncers are the thing we care about). Then, when creating a new syncer, it'd be great to let user choose from existing projects/servers or let them create a new project/server.

Locally, I already got multiple syncers working (by adding them manually in `Syncers.json`), but we need the UI of course. Thanks so much for the work you've put in, we just need a bit more and we'll have it ready.

Let me know if you have any questions - let's talk it through.

```
                                  Syncer
            |-----------------------|------------------------|
        Project                                           Server         
(Xcode Project + GitHub Config)
```